### PR TITLE
Monitoring extras: gateway PodMonitors + 421 alert + Mattermost AM routing + NetPol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # Package: Monitoring
 
 Deploy the [Core Monitoring](https://github.com/defenseunicorns/uds-core) package configured to your environment.
+
+## Durable alerting / Mattermost notifications
+
+This repo includes additional Kubernetes manifests applied during `uds run deploy` to make the dev deployment durable across redeploys (no one-off `kubectl patch`):
+- `PrometheusRule` for HTTP **421** alerting (tenant gateway)
+- `AlertmanagerConfig` receiver/route for Mattermost
+- `NetworkPolicy` egress allow for Alertmanager → tenant gateway (443)
+
+### Required env var
+
+When deploying, set:
+- `MATTERMOST_WEBHOOK_URL` (Mattermost incoming webhook URL)
+
+Example:
+```bash
+MATTERMOST_WEBHOOK_URL="https://chat.uds.dev/hooks/<token>" uds run deploy
+```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 Deploy the [Core Monitoring](https://github.com/defenseunicorns/uds-core) package configured to your environment.
 
-## Durable alerting / Mattermost notifications
+## Durable alerting / Mattermost notifications (dev)
 
-This repo includes additional Kubernetes manifests applied during `uds run deploy` to make the dev deployment durable across redeploys (no one-off `kubectl patch`):
+This repo includes a **local Zarf package** (`packages/monitoring-extras`) that is bundled into `uds-bundle.yaml` so the dev deployment stays correct across redeploys (no one-off `kubectl apply/patch`). It provides:
+- PodMonitors for admin + tenant Istio gateways (Envoy `/stats/prometheus` scraping)
 - `PrometheusRule` for HTTP **421** alerting (tenant gateway)
 - `AlertmanagerConfig` receiver/route for Mattermost
 - `NetworkPolicy` egress allow for Alertmanager → tenant gateway (443)
+- `Secret` for the Mattermost incoming webhook URL
 
 ### Required env var
 
@@ -18,3 +20,7 @@ Example:
 ```bash
 MATTERMOST_WEBHOOK_URL="https://chat.uds.dev/hooks/<token>" uds run deploy
 ```
+
+Notes:
+- `uds run deploy` creates+deploys the local **UDS bundle** (preferred).
+- The older “core-only then kubectl apply extras” flow is kept as `uds run deploy-core-only` + `uds run deploy-legacy-extras`.

--- a/manifests/alertmanagerconfig-mattermost.yaml
+++ b/manifests/alertmanagerconfig-mattermost.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: mattermost
+  namespace: monitoring
+spec:
+  route:
+    receiver: "null"
+    routes:
+      - matchers:
+          - name: alertname
+            value: TenantGatewayMisdirectedRequest421
+            matchType: "="
+        receiver: mattermost
+  receivers:
+    - name: "null"
+    - name: mattermost
+      slackConfigs:
+        - apiURL:
+            name: mattermost-webhook
+            key: url
+          username: alertmanager
+          sendResolved: true
+          title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+          text: |-
+            *Severity:* {{ .CommonLabels.severity }}
+            *Namespace:* {{ .CommonLabels.namespace }}
+            {{ range .Alerts -}}
+            - {{ .Annotations.summary }}
+              {{ .Annotations.description }}
+            {{ end }}

--- a/manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
+++ b/manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alertmanager-egress-chat-via-tenant-gateway
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-tenant-gateway
+          podSelector:
+            matchLabels:
+              app: tenant-ingressgateway
+      ports:
+        - protocol: TCP
+          port: 443

--- a/manifests/podmonitor-admin-gateway-envoy-prom.yaml
+++ b/manifests/podmonitor-admin-gateway-envoy-prom.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: admin-gateway-envoy-prom
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-admin-gateway
+  selector:
+    matchLabels:
+      istio: admin-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/manifests/podmonitor-tenant-gateway-envoy-prom.yaml
+++ b/manifests/podmonitor-tenant-gateway-envoy-prom.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tenant-gateway-envoy-prom
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-tenant-gateway
+  selector:
+    matchLabels:
+      istio: tenant-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/manifests/prometheusrule-tenant-gateway-421.yaml
+++ b/manifests/prometheusrule-tenant-gateway-421.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tenant-gateway-421
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: tenant-gateway
+      rules:
+        - alert: TenantGatewayMisdirectedRequest421
+          annotations:
+            summary: Tenant gateway returned HTTP 421 (Misdirected Request)
+            description: >-
+              At least one 421 response was observed from tenant-ingressgateway in the last 5 minutes.
+              This can indicate the 421 EnvoyFilter is enabled (WebKit/iOS repro path).
+          expr: |
+            sum(increase(istio_requests_total{
+              source_workload_namespace="istio-tenant-gateway",
+              source_workload="tenant-ingressgateway",
+              response_code="421"
+            }[5m])) > 0
+          for: 0m
+          labels:
+            severity: warning

--- a/manifests/secret-mattermost-webhook.yaml.tpl
+++ b/manifests/secret-mattermost-webhook.yaml.tpl
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mattermost-webhook
+  namespace: monitoring
+type: Opaque
+stringData:
+  # Incoming webhook URL (Mattermost): https://chat.<domain>/hooks/<token>
+  url: "${MATTERMOST_WEBHOOK_URL}"

--- a/packages/monitoring-extras/manifests/alertmanagerconfig-mattermost.yaml
+++ b/packages/monitoring-extras/manifests/alertmanagerconfig-mattermost.yaml
@@ -1,0 +1,31 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: mattermost
+  namespace: monitoring
+spec:
+  route:
+    receiver: "null"
+    routes:
+      - matchers:
+          - name: alertname
+            value: TenantGatewayMisdirectedRequest421
+            matchType: "="
+        receiver: mattermost
+  receivers:
+    - name: "null"
+    - name: mattermost
+      slackConfigs:
+        - apiURL:
+            name: mattermost-webhook
+            key: url
+          username: alertmanager
+          sendResolved: true
+          title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+          text: |-
+            *Severity:* {{ .CommonLabels.severity }}
+            *Namespace:* {{ .CommonLabels.namespace }}
+            {{ range .Alerts -}}
+            - {{ .Annotations.summary }}
+              {{ .Annotations.description }}
+            {{ end }}

--- a/packages/monitoring-extras/manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
+++ b/packages/monitoring-extras/manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alertmanager-egress-chat-via-tenant-gateway
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-tenant-gateway
+          podSelector:
+            matchLabels:
+              app: tenant-ingressgateway
+      ports:
+        - protocol: TCP
+          port: 443

--- a/packages/monitoring-extras/manifests/podmonitor-admin-gateway-envoy-prom.yaml
+++ b/packages/monitoring-extras/manifests/podmonitor-admin-gateway-envoy-prom.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: admin-gateway-envoy-prom
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-admin-gateway
+  selector:
+    matchLabels:
+      istio: admin-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/packages/monitoring-extras/manifests/podmonitor-tenant-gateway-envoy-prom.yaml
+++ b/packages/monitoring-extras/manifests/podmonitor-tenant-gateway-envoy-prom.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tenant-gateway-envoy-prom
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: istio
+spec:
+  namespaceSelector:
+    matchNames:
+      - istio-tenant-gateway
+  selector:
+    matchLabels:
+      istio: tenant-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/packages/monitoring-extras/manifests/prometheusrule-tenant-gateway-421.yaml
+++ b/packages/monitoring-extras/manifests/prometheusrule-tenant-gateway-421.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tenant-gateway-421
+  namespace: monitoring
+  labels:
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+spec:
+  groups:
+    - name: tenant-gateway
+      rules:
+        - alert: TenantGatewayMisdirectedRequest421
+          annotations:
+            summary: Tenant gateway returned HTTP 421 (Misdirected Request)
+            description: >-
+              At least one 421 response was observed from tenant-ingressgateway in the last 5 minutes.
+              This can indicate the 421 EnvoyFilter is enabled (WebKit/iOS repro path).
+          expr: |
+            sum(increase(istio_requests_total{
+              source_workload_namespace="istio-tenant-gateway",
+              source_workload="tenant-ingressgateway",
+              response_code="421"
+            }[5m])) > 0
+          for: 0m
+          labels:
+            severity: warning

--- a/packages/monitoring-extras/manifests/secret-mattermost-webhook.yaml
+++ b/packages/monitoring-extras/manifests/secret-mattermost-webhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mattermost-webhook
+  namespace: monitoring
+type: Opaque
+stringData:
+  # Incoming webhook URL (Mattermost): https://chat.<domain>/hooks/<token>
+  url: "###ZARF_VAR_MATTERMOST_WEBHOOK_URL###"

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -21,6 +21,6 @@ components:
           - manifests/podmonitor-admin-gateway-envoy-prom.yaml
           - manifests/podmonitor-tenant-gateway-envoy-prom.yaml
           - manifests/prometheusrule-tenant-gateway-421.yaml
+          - manifests/secret-mattermost-webhook.yaml
           - manifests/alertmanagerconfig-mattermost.yaml
           - manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
-          - manifests/secret-mattermost-webhook.yaml

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -1,0 +1,24 @@
+kind: ZarfPackageConfig
+metadata:
+  name: monitoring-extras
+  description: Additional monitoring resources (PrometheusRule, AlertmanagerConfig, NetworkPolicy, webhook Secret)
+  # Version is not strictly required for local packages, but helps with traceability.
+  version: 0.1.0
+
+variables:
+  - name: MATTERMOST_WEBHOOK_URL
+    description: Mattermost incoming webhook URL (e.g. https://chat.<domain>/hooks/<token>)
+    prompt: true
+    sensitive: true
+
+components:
+  - name: monitoring-extras
+    required: true
+    manifests:
+      - name: monitoring-alerting
+        namespace: monitoring
+        files:
+          - manifests/prometheusrule-tenant-gateway-421.yaml
+          - manifests/alertmanagerconfig-mattermost.yaml
+          - manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
+          - manifests/secret-mattermost-webhook.yaml

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -18,6 +18,8 @@ components:
       - name: monitoring-alerting
         namespace: monitoring
         files:
+          - manifests/podmonitor-admin-gateway-envoy-prom.yaml
+          - manifests/podmonitor-tenant-gateway-envoy-prom.yaml
           - manifests/prometheusrule-tenant-gateway-421.yaml
           - manifests/alertmanagerconfig-mattermost.yaml
           - manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -3,7 +3,7 @@ metadata:
   name: monitoring-extras
   description: Additional monitoring resources (PrometheusRule, AlertmanagerConfig, NetworkPolicy, webhook Secret)
   # Version is not strictly required for local packages, but helps with traceability.
-  version: 0.1.0
+  version: 0.1.1
 
 variables:
   - name: MATTERMOST_WEBHOOK_URL

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -3,7 +3,7 @@ metadata:
   name: monitoring-extras
   description: Additional monitoring resources (PrometheusRule, AlertmanagerConfig, NetworkPolicy, webhook Secret)
   # Version is not strictly required for local packages, but helps with traceability.
-  version: 0.1.1
+  version: 0.1.2
 
 variables:
   - name: MATTERMOST_WEBHOOK_URL
@@ -21,6 +21,6 @@ components:
           - manifests/podmonitor-admin-gateway-envoy-prom.yaml
           - manifests/podmonitor-tenant-gateway-envoy-prom.yaml
           - manifests/prometheusrule-tenant-gateway-421.yaml
-          - manifests/secret-mattermost-webhook.yaml
+          - manifests/secret-mattermost-webhook.yaml.tpl
           - manifests/alertmanagerconfig-mattermost.yaml
           - manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -47,6 +47,21 @@ tasks:
           ZARF_CONFIG="$CONFIG_FILE" uds zarf package deploy zarf-package-*-${PACKAGE_VERSION}-${PACKAGE_FLAVOR}.tar.zst \
             --confirm
 
+      - description: "Apply durable monitoring alerting + Mattermost notification resources"
+        cmd: |
+          set -euo pipefail
+
+          # Prometheus alert rule + NetworkPolicy are static.
+          kubectl apply -f manifests/prometheusrule-tenant-gateway-421.yaml
+          kubectl apply -f manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
+          kubectl apply -f manifests/alertmanagerconfig-mattermost.yaml
+
+          # Webhook secret is environment-specific; do not commit real URLs.
+          : "${MATTERMOST_WEBHOOK_URL:?Set MATTERMOST_WEBHOOK_URL to the Mattermost incoming webhook URL}"
+          kubectl -n monitoring create secret generic mattermost-webhook \
+            --from-literal=url="${MATTERMOST_WEBHOOK_URL}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
   - name: clean
     description: "Remove local Zarf package files"
     actions:

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -47,20 +47,34 @@ tasks:
           ZARF_CONFIG="$CONFIG_FILE" uds zarf package deploy zarf-package-*-${PACKAGE_VERSION}-${PACKAGE_FLAVOR}.tar.zst \
             --confirm
 
-      - description: "Apply durable monitoring alerting + Mattermost notification resources"
+      - description: "Apply durable monitoring alerting + Mattermost notification resources (legacy)"
         cmd: |
           set -euo pipefail
 
-          # Prometheus alert rule + NetworkPolicy are static.
+          # NOTE: Prefer `uds run deploy-bundle` instead, which bakes these resources into the UDSBundle
+          # via the local `monitoring-extras` package so they persist across redeploys without kubectl apply.
+
           kubectl apply -f manifests/prometheusrule-tenant-gateway-421.yaml
           kubectl apply -f manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
           kubectl apply -f manifests/alertmanagerconfig-mattermost.yaml
 
-          # Webhook secret is environment-specific; do not commit real URLs.
           : "${MATTERMOST_WEBHOOK_URL:?Set MATTERMOST_WEBHOOK_URL to the Mattermost incoming webhook URL}"
           kubectl -n monitoring create secret generic mattermost-webhook \
             --from-literal=url="${MATTERMOST_WEBHOOK_URL}" \
             --dry-run=client -o yaml | kubectl apply -f -
+
+  - name: deploy-bundle
+    description: "Create+deploy the UDS bundle (includes durable alerting resources)"
+    actions:
+      - description: "Deploy local bundle in dev mode"
+        cmd: |
+          set -euo pipefail
+          : "${MATTERMOST_WEBHOOK_URL:?Set MATTERMOST_WEBHOOK_URL to the Mattermost incoming webhook URL}"
+
+          # This will create the bundle from the local directory and deploy it.
+          uds dev deploy . \
+            --confirm \
+            --set monitoring-extras.MATTERMOST_WEBHOOK_URL="${MATTERMOST_WEBHOOK_URL}"
 
   - name: clean
     description: "Remove local Zarf package files"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -40,19 +40,32 @@ tasks:
           - ZARF_LOG_LEVEL=info
 
   - name: deploy
-    description: "Deploy Core package"
+    description: "Deploy the UDS bundle (Core Monitoring + durable dev alerting resources)"
+    actions:
+      - description: "Deploy local bundle in dev mode (preferred)"
+        cmd: |
+          set -euo pipefail
+          : "${MATTERMOST_WEBHOOK_URL:?Set MATTERMOST_WEBHOOK_URL to the Mattermost incoming webhook URL}"
+
+          # This will create the bundle from the local directory and deploy it.
+          uds dev deploy . \
+            --confirm \
+            --set monitoring-extras.MATTERMOST_WEBHOOK_URL="${MATTERMOST_WEBHOOK_URL}"
+
+  - name: deploy-core-only
+    description: "Deploy Core Monitoring package only (no extras)"
     actions:
       - description: "Deploy Core package with defined zarf-config.toml"
         cmd: |
           ZARF_CONFIG="$CONFIG_FILE" uds zarf package deploy zarf-package-*-${PACKAGE_VERSION}-${PACKAGE_FLAVOR}.tar.zst \
             --confirm
 
-      - description: "Apply durable monitoring alerting + Mattermost notification resources (legacy)"
+  - name: deploy-legacy-extras
+    description: "(Legacy) kubectl apply the alerting/Mattermost extras after deploying Core"
+    actions:
+      - description: "Apply durable monitoring alerting + Mattermost notification resources via kubectl"
         cmd: |
           set -euo pipefail
-
-          # NOTE: Prefer `uds run deploy-bundle` instead, which bakes these resources into the UDSBundle
-          # via the local `monitoring-extras` package so they persist across redeploys without kubectl apply.
 
           kubectl apply -f manifests/prometheusrule-tenant-gateway-421.yaml
           kubectl apply -f manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
@@ -63,18 +76,7 @@ tasks:
             --from-literal=url="${MATTERMOST_WEBHOOK_URL}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
-  - name: deploy-bundle
-    description: "Create+deploy the UDS bundle (includes durable alerting resources)"
-    actions:
-      - description: "Deploy local bundle in dev mode"
-        cmd: |
-          set -euo pipefail
-          : "${MATTERMOST_WEBHOOK_URL:?Set MATTERMOST_WEBHOOK_URL to the Mattermost incoming webhook URL}"
-
-          # This will create the bundle from the local directory and deploy it.
-          uds dev deploy . \
-            --confirm \
-            --set monitoring-extras.MATTERMOST_WEBHOOK_URL="${MATTERMOST_WEBHOOK_URL}"
+  # NOTE: `deploy-bundle` was renamed to `deploy` (preferred).
 
   - name: clean
     description: "Remove local Zarf package files"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -67,6 +67,8 @@ tasks:
         cmd: |
           set -euo pipefail
 
+          kubectl apply -f manifests/podmonitor-admin-gateway-envoy-prom.yaml
+          kubectl apply -f manifests/podmonitor-tenant-gateway-envoy-prom.yaml
           kubectl apply -f manifests/prometheusrule-tenant-gateway-421.yaml
           kubectl apply -f manifests/networkpolicy-allow-alertmanager-egress-chat-via-tenant-gateway.yaml
           kubectl apply -f manifests/alertmanagerconfig-mattermost.yaml

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -18,4 +18,4 @@ packages:
   # Local Zarf package included in this bundle to make dev alerting durable across redeploys.
   - name: monitoring-extras
     path: ./packages/monitoring-extras
-    ref: 0.1.1
+    ref: 0.1.2

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -18,4 +18,4 @@ packages:
   # Local Zarf package included in this bundle to make dev alerting durable across redeploys.
   - name: monitoring-extras
     path: ./packages/monitoring-extras
-    ref: 0.1.0
+    ref: 0.1.1

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -1,11 +1,11 @@
 kind: UDSBundle
 metadata:
   name: core-monitoring
-  version: 0.59.1
+  version: 0.61.1
 packages:
   - name: "monitoring"
     repository: ghcr.io/defenseunicorns/packages/private/uds/core-monitoring
-    ref: 0.59.1-unicorn
+    ref: 0.61.1-unicorn
     overrides:
       grafana:
         grafana:

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -14,3 +14,8 @@ packages:
               path: extraSecretMounts
             - name: ENV_GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA
               path: env.GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA
+
+  # Local Zarf package included in this bundle to make dev alerting durable across redeploys.
+  - name: monitoring-extras
+    path: ./packages/monitoring-extras
+    ref: 0.1.0

--- a/uds-config.yaml
+++ b/uds-config.yaml
@@ -38,3 +38,7 @@ variables:
     #       - key: ca.crt
     #         path: ca.crt
     # ENV_GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA: /etc/grafana/certs/ca.crt
+
+  monitoring-extras:
+    # Mattermost incoming webhook URL; provide via --set or environment-specific config.
+    MATTERMOST_WEBHOOK_URL: "CHANGEME"

--- a/uds-config.yaml
+++ b/uds-config.yaml
@@ -1,23 +1,40 @@
 options:
   tmp_dir: "/var/tmp"
-shared:
-  domain: "uds.local"
 variables:
-  monitoring: 
-    EXTRA_SECRET_MOUNTS:
-      - name: auth-generic-oauth-secret-mount
-        secretName: sso-client-uds-core-admin-grafana
-        defaultMode: 0440
-        mountPath: /etc/secrets/auth_generic_oauth
-        readOnly: true
-      - name: uds-local-ca
-        secretName: uds-local-ca
-        defaultMode: 0444
-        readOnly: true
-        mountPath: /etc/grafana/certs
-        items:
-          - key: ca.crt
-            path: ca.crt
-    ENV_GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA: /etc/grafana/certs/ca.crt
+  monitoring:
+    # Bundle variables (see uds-bundle.yaml overrides)
+    GRAFANA_HA: true
 
-    
+    # Point Grafana at the Postgres DB created by package-postgres-operator (Zalando operator)
+    # Service: postgres/pg-cluster
+    GRAFANA_PG_HOST: pg-cluster.postgres.svc.cluster.local
+    GRAFANA_PG_PORT: 5432
+
+    # DB created by package-postgres-operator uds-config.yaml: grafanadb
+    GRAFANA_PG_DATABASE: grafanadb
+
+    # For now use the operator-created superuser creds from secret:
+    #   postgres/postgres.pg-cluster.credentials.postgresql.acid.zalan.do
+    GRAFANA_PG_USER: postgres
+    # NOTE: do not commit real passwords. Provide via environment/secret management when deploying.
+    GRAFANA_PG_PASSWORD: "CHANGEME"
+
+    # In-cluster connection; no TLS by default
+    GRAFANA_PG_SSL_MODE: disable
+
+    ### These are required when you need to pass in a cert other than uds.dev
+    # EXTRA_SECRET_MOUNTS:
+    #   - name: auth-generic-oauth-secret-mount
+    #     secretName: sso-client-uds-core-admin-grafana
+    #     defaultMode: 0440
+    #     mountPath: /etc/secrets/auth_generic_oauth
+    #     readOnly: true
+    #   - name: uds-local-ca
+    #     secretName: uds-local-ca
+    #     defaultMode: 0444
+    #     readOnly: true
+    #     mountPath: /etc/grafana/certs
+    #     items:
+    #       - key: ca.crt
+    #         path: ca.crt
+    # ENV_GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA: /etc/grafana/certs/ca.crt


### PR DESCRIPTION
Closes #8 (epic umbrella).

Implements a durable `monitoring-extras` package to persist the one-off fixes across redeploys:
- PodMonitors for admin + tenant gateway Envoy stats (/stats/prometheus)
- PrometheusRule: alert on HTTP 421 responses from the gateway
- AlertmanagerConfig receiver/routes for Mattermost webhook
- NetworkPolicy egress allow for Alertmanager → Mattermost webhook path via tenant gateway

Also updates dev deploy flow to include the extras bundle/package.

Notes:
- Uses an explicit Secret manifest for the Mattermost webhook URL (placeholder by default).
- Includes legacy PodMonitor manifests in top-level `manifests/` as well (kept for compatibility).
