### PR TITLE
Add monitoring-extras: 421 alert + Mattermost receiver + egress allow

### DIFF
--- a/packages/monitoring-extras/chart/Chart.yaml
+++ b/packages/monitoring-extras/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: monitoring-extras
+description: Extra monitoring resources (PrometheusRule, AlertmanagerConfig, NetworkPolicy, webhook Secret)
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/packages/monitoring-extras/chart/templates/_helpers.tpl
+++ b/packages/monitoring-extras/chart/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "monitoring-extras.namespace" -}}
+{{- default "monitoring" .Values.namespace -}}
+{{- end -}}

--- a/packages/monitoring-extras/chart/templates/alertmanagerconfig-mattermost.yaml
+++ b/packages/monitoring-extras/chart/templates/alertmanagerconfig-mattermost.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.mattermost.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1alpha1") -}}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: {{ .Values.mattermost.alertmanagerConfig.name | quote }}
+  namespace: {{ include "monitoring-extras.namespace" . }}
+spec:
+  route:
+    receiver: "null"
+    routes:
+      - matchers:
+          - name: alertname
+            value: {{ .Values.mattermost.alertmanagerConfig.route.matchAlertName | quote }}
+            matchType: "="
+        receiver: mattermost
+  receivers:
+    - name: "null"
+    - name: mattermost
+      slackConfigs:
+        - apiURL:
+            name: {{ .Values.mattermost.secretName | quote }}
+            key: url
+          username: alertmanager
+          sendResolved: true
+          title: "[{{`{{ .Status | toUpper }}`}}] {{`{{ .CommonLabels.alertname }}`}}"
+          text: |-
+            *Severity:* {{`{{ .CommonLabels.severity }}`}}
+            *Namespace:* {{`{{ .CommonLabels.namespace }}`}}
+            {{`{{ range .Alerts -}}`}}
+            - {{`{{ .Annotations.summary }}`}}
+              {{`{{ .Annotations.description }}`}}
+            {{`{{ end }}`}}
+{{- end }}

--- a/packages/monitoring-extras/chart/templates/networkpolicy-alertmanager-egress.yaml
+++ b/packages/monitoring-extras/chart/templates/networkpolicy-alertmanager-egress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Values.networkPolicy.name | quote }}
+  namespace: {{ include "monitoring-extras.namespace" . }}
+spec:
+  podSelector:
+    matchLabels:
+{{ toYaml .Values.networkPolicy.alertmanagerPodSelector | indent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.tenantGateway.namespace | quote }}
+          podSelector:
+            matchLabels:
+{{ toYaml .Values.networkPolicy.tenantGateway.podSelector | indent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.tenantGateway.port }}
+{{- end }}

--- a/packages/monitoring-extras/chart/templates/networkpolicy-alertmanager-egress.yaml
+++ b/packages/monitoring-extras/chart/templates/networkpolicy-alertmanager-egress.yaml
@@ -11,6 +11,7 @@ spec:
   policyTypes:
     - Egress
   egress:
+    # Option A: allow egress to tenant gateway pods
     - to:
         - namespaceSelector:
             matchLabels:
@@ -21,4 +22,18 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.networkPolicy.tenantGateway.port }}
+
+{{- if .Values.networkPolicy.ipBlock.enabled }}
+    # Option B: allow egress to a specific LoadBalancer/IP
+    - to:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.ipBlock.cidr | quote }}
+{{- if .Values.networkPolicy.ipBlock.except }}
+            except:
+{{ toYaml .Values.networkPolicy.ipBlock.except | indent 14 }}
+{{- end }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.networkPolicy.ipBlock.port }}
+{{- end }}
 {{- end }}

--- a/packages/monitoring-extras/chart/templates/prometheusrule-tenant-gateway-421.yaml
+++ b/packages/monitoring-extras/chart/templates/prometheusrule-tenant-gateway-421.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.prometheusRule.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Values.prometheusRule.name | quote }}
+  namespace: {{ include "monitoring-extras.namespace" . }}
+  labels:
+{{ toYaml .Values.prometheusRule.labels | indent 4 }}
+spec:
+  groups:
+    - name: tenant-gateway
+      rules:
+        - alert: {{ .Values.prometheusRule.alertName | quote }}
+          annotations:
+            summary: Tenant gateway returned HTTP 421 (Misdirected Request)
+            description: >-
+              At least one 421 response was observed from tenant-ingressgateway in the last {{ .Values.prometheusRule.window }}.
+              This can indicate the 421 EnvoyFilter is enabled (WebKit/iOS repro path).
+          expr: |
+            sum(increase(istio_requests_total{
+              source_workload_namespace={{ .Values.prometheusRule.expr.source_workload_namespace | quote }},
+              source_workload={{ .Values.prometheusRule.expr.source_workload | quote }},
+              response_code="421"
+            }[{{ .Values.prometheusRule.window }}])) > 0
+          for: 0m
+          labels:
+            severity: {{ .Values.prometheusRule.severity | quote }}
+{{- end }}

--- a/packages/monitoring-extras/chart/templates/secret-mattermost-webhook.yaml
+++ b/packages/monitoring-extras/chart/templates/secret-mattermost-webhook.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.mattermost.enabled .Values.mattermost.webhookUrl -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.mattermost.secretName | quote }}
+  namespace: {{ include "monitoring-extras.namespace" . }}
+type: Opaque
+stringData:
+  url: {{ .Values.mattermost.webhookUrl | quote }}
+{{- end }}

--- a/packages/monitoring-extras/chart/values.yaml
+++ b/packages/monitoring-extras/chart/values.yaml
@@ -1,0 +1,35 @@
+namespace: monitoring
+
+prometheusRule:
+  enabled: true
+  name: tenant-gateway-421
+  # Prometheus-operator label selectors vary by distro; keep existing labels but allow override.
+  labels:
+    prometheus: kube-prometheus-stack-prometheus
+    role: alert-rules
+  alertName: TenantGatewayMisdirectedRequest421
+  severity: warning
+  window: 5m
+  expr:
+    source_workload_namespace: istio-tenant-gateway
+    source_workload: tenant-ingressgateway
+
+mattermost:
+  enabled: true
+  secretName: mattermost-webhook
+  webhookUrl: ""  # set via Zarf var / values override
+  alertmanagerConfig:
+    name: mattermost
+    route:
+      matchAlertName: TenantGatewayMisdirectedRequest421
+
+networkPolicy:
+  enabled: true
+  name: allow-alertmanager-egress-chat-via-tenant-gateway
+  alertmanagerPodSelector:
+    app.kubernetes.io/name: alertmanager
+  tenantGateway:
+    namespace: istio-tenant-gateway
+    podSelector:
+      app: tenant-ingressgateway
+    port: 443

--- a/packages/monitoring-extras/chart/values.yaml
+++ b/packages/monitoring-extras/chart/values.yaml
@@ -28,8 +28,19 @@ networkPolicy:
   name: allow-alertmanager-egress-chat-via-tenant-gateway
   alertmanagerPodSelector:
     app.kubernetes.io/name: alertmanager
+
+  # Option A (default): allow egress to the tenant gateway pods (works if the webhook URL resolves
+  # to an in-cluster Service/Pod IP via CNI service handling).
   tenantGateway:
     namespace: istio-tenant-gateway
     podSelector:
       app: tenant-ingressgateway
+    port: 443
+
+  # Option B: allow egress directly to an IP/CIDR (works reliably when the webhook URL resolves
+  # to a MetalLB/LoadBalancer IP like 172.20.0.200).
+  ipBlock:
+    enabled: false
+    cidr: ""   # e.g. "172.20.0.200/32"
+    except: [] # optional
     port: 443

--- a/packages/monitoring-extras/zarf.yaml
+++ b/packages/monitoring-extras/zarf.yaml
@@ -1,0 +1,24 @@
+kind: ZarfPackageConfig
+metadata:
+  name: monitoring-extras
+  description: Additional monitoring resources (PrometheusRule, AlertmanagerConfig, NetworkPolicy, webhook Secret)
+  # Version is not strictly required for local packages, but helps with traceability.
+  version: 0.1.0
+
+variables:
+  - name: MATTERMOST_WEBHOOK_URL
+    description: Mattermost incoming webhook URL (e.g. https://chat.<domain>/hooks/<token>)
+    prompt: true
+    sensitive: true
+
+components:
+  - name: monitoring-extras
+    required: true
+    charts:
+      - name: monitoring-extras
+        version: 0.1.0
+        localPath: chart
+        namespace: monitoring
+        variables:
+          - name: MATTERMOST_WEBHOOK_URL
+            path: mattermost.webhookUrl

--- a/scripts/test-monitoring-extras-helm.sh
+++ b/scripts/test-monitoring-extras-helm.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHART_DIR="$ROOT_DIR/packages/monitoring-extras/chart"
+
+if ! command -v helm >/dev/null 2>&1; then
+  echo "helm is required for this test" >&2
+  exit 1
+fi
+
+# Render with required CRDs.
+out="$(helm template monitoring-extras "$CHART_DIR" \
+  --api-versions monitoring.coreos.com/v1 \
+  --api-versions monitoring.coreos.com/v1alpha1 \
+  --set mattermost.webhookUrl=https://example.invalid/webhook)"
+
+echo "$out" | grep -q "kind: PrometheusRule"
+echo "$out" | grep -q "name: \"tenant-gateway-421\""
+
+echo "$out" | grep -q "kind: AlertmanagerConfig"
+echo "$out" | grep -q "name: \"mattermost\""
+
+echo "$out" | grep -q "kind: NetworkPolicy"
+echo "$out" | grep -q "name: \"allow-alertmanager-egress-chat-via-tenant-gateway\""
+
+echo "$out" | grep -q "kind: Secret"
+echo "$out" | grep -q "name: \"mattermost-webhook\""
+
+# Render without CRDs - should not include PrometheusRule/AlertmanagerConfig.
+out2="$(helm template monitoring-extras "$CHART_DIR" \
+  --set mattermost.webhookUrl=https://example.invalid/webhook)"
+if echo "$out2" | grep -q "kind: PrometheusRule"; then
+  echo "expected no PrometheusRule output when CRD is not available" >&2
+  exit 1
+fi
+if echo "$out2" | grep -q "kind: AlertmanagerConfig"; then
+  echo "expected no AlertmanagerConfig output when CRD is not available" >&2
+  exit 1
+fi
+
+# Secret should not render when webhookUrl is empty.
+out3="$(helm template monitoring-extras "$CHART_DIR" \
+  --api-versions monitoring.coreos.com/v1alpha1)"
+if echo "$out3" | grep -q "kind: Secret"; then
+  echo "expected no Secret output when mattermost.webhookUrl is empty" >&2
+  exit 1
+fi
+
+echo "ok"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,5 +1,6 @@
 includes:
   - bundles: ./tasks/bundles.yaml
+  - packages: ./tasks/packages.yaml
 
 variables:
   - name: REGISTRY

--- a/tasks/packages.yaml
+++ b/tasks/packages.yaml
@@ -1,0 +1,36 @@
+# Copyright 2024 Defense Unicorns
+# SPDX-License-Identifier: AGPL-3.0-or-later OR LicenseRef-Defense-Unicorns-Commercial
+# yaml-language-server: $schema=https://raw.githubusercontent.com/defenseunicorns/uds-cli/main/tasks.schema.json
+
+variables:
+  - name: ARCH
+    description: "What architecture to use"
+  - name: BUNDLE
+    description: The name of the bundle you are working with
+
+tasks:
+  - name: create
+    description: Create the UDS Zarf Package in the repository
+    inputs:
+      options:
+        description: For setting create time variables and flags
+      path:
+        description: Path to the zarf package definition being created
+        default: .
+      architecture:
+        description: The architecture of the package to create
+        default: ${UDS_ARCH}
+    actions:
+      - cmd: ./uds zarf package create ${{ .inputs.path }} --confirm --no-progress --architecture="${{ .inputs.architecture }}" ${{ .inputs.options }}
+
+  - name: monitoring-extras
+    description: "Local package with PrometheusRule 421 + AlertmanagerConfig Mattermost + NetworkPolicy egress"
+    actions:
+      - task: create
+        with:
+          path: packages/monitoring-extras
+
+  - name: test-monitoring-extras-helm
+    description: "Smoke-test Helm templates for monitoring-extras"
+    actions:
+      - cmd: ./scripts/test-monitoring-extras-helm.sh


### PR DESCRIPTION
Upstreams the one-off alerting fixes into a durable local Helm/Zarf package.

Adds packages/monitoring-extras:
- PrometheusRule: tenant gateway HTTP 421 alert
- AlertmanagerConfig: route the alert to Mattermost via incoming webhook (Slack receiver)
- NetworkPolicy: allow Alertmanager egress to the tenant gateway for webhook delivery
- Helm template smoke test (scripts/test-monitoring-extras-helm.sh)
- Wires the local package into uds-bundle.yaml

Closes:
- #5 (421 PrometheusRule)
- #6 (Mattermost receiver/routes)
- #7 (NetworkPolicy egress allow)

Context:
- #8 (EPIC B/C/D)
