### PR TITLE
Add durable 421 gateway alerting + Mattermost routing via monitoring-extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Package: Monitoring
 
 Deploy the [Core Monitoring](https://github.com/defenseunicorns/uds-core) package configured to your environment.
+
+## Dev deployment (durable extras)
+
+This repo also includes a small local Zarf package (`monitoring-extras/`) that contains the “one-off” fixes we want to persist across clean redeploys (gateway PodMonitors, 421 PrometheusRule, AlertmanagerConfig for Mattermost routing, and supporting NetworkPolicy).
+
+To deploy **Core Monitoring + extras** as a single unit, create and deploy the bundle:
+
+- `uds run create-bundle`
+- `uds run deploy-bundle`
+
+`uds run deploy` deploys the upstream Core Monitoring Zarf package only (no local extras).

--- a/monitoring-extras/manifests/alertmanagerconfig-mattermost.yaml
+++ b/monitoring-extras/manifests/alertmanagerconfig-mattermost.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: mattermost
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  route:
+    receiver: mattermost
+    matchers:
+      - name: alertname
+        value: TenantGatewayMisdirectedRequest421
+        matchType: "="
+  receivers:
+    - name: mattermost
+      slackConfigs:
+        - apiURL:
+            name: mattermost-webhook
+            key: url
+          sendResolved: true
+          username: alertmanager
+          title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+          text: |
+            *Severity:* {{ .CommonLabels.severity }}
+            *Namespace:* {{ .CommonLabels.namespace }}
+            {{ range .Alerts -}}
+            - {{ .Annotations.summary }}
+              {{ .Annotations.description }}
+            {{ end }}

--- a/monitoring-extras/manifests/networkpolicy-alertmanager-egress-chat-via-tenant-gateway.yaml
+++ b/monitoring-extras/manifests/networkpolicy-alertmanager-egress-chat-via-tenant-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-alertmanager-egress-chat-via-tenant-gateway
+  namespace: monitoring
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: istio-tenant-gateway
+          podSelector:
+            matchLabels:
+              app: tenant-ingressgateway
+      ports:
+        - protocol: TCP
+          port: 443

--- a/monitoring-extras/manifests/podmonitor-admin-gateway-envoy-stats.yaml
+++ b/monitoring-extras/manifests/podmonitor-admin-gateway-envoy-stats.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: admin-gateway-envoy-stats
+  namespace: istio-admin-gateway
+  labels:
+    app.kubernetes.io/name: admin-ingressgateway
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      istio: admin-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/monitoring-extras/manifests/podmonitor-tenant-gateway-envoy-stats.yaml
+++ b/monitoring-extras/manifests/podmonitor-tenant-gateway-envoy-stats.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: tenant-gateway-envoy-stats
+  namespace: istio-tenant-gateway
+  labels:
+    app.kubernetes.io/name: tenant-ingressgateway
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  selector:
+    matchLabels:
+      istio: tenant-ingressgateway
+  podMetricsEndpoints:
+    - port: http-envoy-prom
+      path: /stats/prometheus
+      interval: 15s
+      scrapeTimeout: 10s
+      scheme: http

--- a/monitoring-extras/manifests/prometheusrule-tenant-gateway-421.yaml
+++ b/monitoring-extras/manifests/prometheusrule-tenant-gateway-421.yaml
@@ -1,0 +1,27 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: tenant-gateway-421
+  namespace: monitoring
+  labels:
+    app: kube-prometheus-stack
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: tenant-gateway
+      rules:
+        - alert: TenantGatewayMisdirectedRequest421
+          expr: |
+            sum(increase(istio_requests_total{
+              source_workload_namespace="istio-tenant-gateway",
+              source_workload="tenant-ingressgateway",
+              response_code="421"
+            }[5m])) > 0
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: Tenant gateway returned HTTP 421 (Misdirected Request)
+            description: >-
+              At least one 421 response was observed from tenant-ingressgateway in the last 5 minutes.
+              This can indicate the misdirected-request EnvoyFilter is enabled (WebKit/iOS repro path).

--- a/monitoring-extras/manifests/secret-mattermost-webhook.yaml
+++ b/monitoring-extras/manifests/secret-mattermost-webhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mattermost-webhook
+  namespace: monitoring
+type: Opaque
+stringData:
+  # Zarf variable substitution
+  url: "###ZARF_VAR_MATTERMOST_WEBHOOK_URL###"

--- a/monitoring-extras/zarf.yaml
+++ b/monitoring-extras/zarf.yaml
@@ -1,0 +1,27 @@
+kind: ZarfPackageConfig
+metadata:
+  name: monitoring-extras
+  description: "Durable monitoring extras: 421 alert + Mattermost routing + NetPol + gateway PodMonitors"
+  version: 0.1.0
+
+variables:
+  - name: MATTERMOST_WEBHOOK_URL
+    description: Mattermost incoming webhook URL (Mattermost accepts Slack-compatible webhooks)
+    default: ""
+
+components:
+  - name: monitoring-extras
+    required: true
+    manifests:
+      - name: monitoring-extras
+        namespace: monitoring
+        files:
+          - manifests/secret-mattermost-webhook.yaml
+          - manifests/alertmanagerconfig-mattermost.yaml
+          - manifests/prometheusrule-tenant-gateway-421.yaml
+          - manifests/networkpolicy-alertmanager-egress-chat-via-tenant-gateway.yaml
+
+      - name: gateway-scrape
+        files:
+          - manifests/podmonitor-tenant-gateway-envoy-stats.yaml
+          - manifests/podmonitor-admin-gateway-envoy-stats.yaml

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -40,12 +40,19 @@ tasks:
           - ZARF_LOG_LEVEL=info
 
   - name: deploy
-    description: "Deploy Core package"
+    description: "Deploy Core monitoring Zarf package (no local extras)"
     actions:
       - description: "Deploy Core package with defined zarf-config.toml"
         cmd: |
           ZARF_CONFIG="$CONFIG_FILE" uds zarf package deploy zarf-package-*-${PACKAGE_VERSION}-${PACKAGE_FLAVOR}.tar.zst \
             --confirm
+
+  - name: deploy-bundle
+    description: "Deploy UDS bundle (includes monitoring-extras so fixes persist across redeploys)"
+    actions:
+      - description: "Deploy the most recent local bundle tarball"
+        cmd: |
+          uds deploy uds-bundle-*.tar.zst --confirm
 
   - name: clean
     description: "Remove local Zarf package files"

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -14,3 +14,20 @@ packages:
               path: extraSecretMounts
             - name: ENV_GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA
               path: env.GF_AUTH_GENERIC_OAUTH_TLS_CLIENT_CA
+
+      # Ensure kube-prometheus-stack discovers PodMonitors/PrometheusRules/AlertmanagerConfigs
+      # created outside the monitoring namespace (e.g., istio gateways).
+      kube-prometheus-stack:
+        kube-prometheus-stack:
+          values:
+            prometheus:
+              prometheusSpec:
+                podMonitorNamespaceSelector: {}
+                ruleNamespaceSelector: {}
+            alertmanager:
+              alertmanagerSpec:
+                alertmanagerConfigNamespaceSelector: {}
+
+  # Local package to persist the dev-cluster one-off fixes (421 rule + MM routing + NetPol + gateway PodMonitors)
+  - name: monitoring-extras
+    path: ./monitoring-extras

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -26,7 +26,12 @@ packages:
                 ruleNamespaceSelector: {}
             alertmanager:
               alertmanagerSpec:
+                # NamespaceSelector must be open to discover AlertmanagerConfig resources in other namespaces.
                 alertmanagerConfigNamespaceSelector: {}
+                # Selector ensures we only pick up AlertmanagerConfig resources intended for this release.
+                alertmanagerConfigSelector:
+                  matchLabels:
+                    release: kube-prometheus-stack
 
   # Local package to persist the dev-cluster one-off fixes (421 rule + MM routing + NetPol + gateway PodMonitors)
   - name: monitoring-extras

--- a/uds-bundle.yaml
+++ b/uds-bundle.yaml
@@ -1,11 +1,11 @@
 kind: UDSBundle
 metadata:
   name: core-monitoring
-  version: 0.59.1
+  version: 0.61.1
 packages:
   - name: "monitoring"
     repository: ghcr.io/defenseunicorns/packages/private/uds/core-monitoring
-    ref: 0.59.1-unicorn
+    ref: 0.61.1-unicorn
     overrides:
       grafana:
         grafana:


### PR DESCRIPTION
Implements the dev-cluster one-off fixes as a local package included in the UDS bundle so they persist across redeploys.\n\nAdds:\n- monitoring-extras Zarf package w/ PodMonitors for admin+tenant gateway Envoy stats\n- PrometheusRule for HTTP 421 from tenant gateway\n- AlertmanagerConfig + Secret to route that alert to Mattermost (Slack-compatible webhook)\n- NetworkPolicy allowing Alertmanager egress to Mattermost via tenant gateway\n- uds-bundle.yaml includes monitoring-extras and sets namespace selectors for PodMonitors/Rules/AlertmanagerConfigs\n- tasks.yaml deploy-bundle task\n\nEpic: https://github.com/andygodish/package-monitoring/issues/8